### PR TITLE
Fix typo in telegramTypes.interface.ts #1569

### DIFF
--- a/src/interfaces/telegramTypes.interface.ts
+++ b/src/interfaces/telegramTypes.interface.ts
@@ -1566,7 +1566,7 @@ export interface TelegramEncryptedPassportElement {
     | 'rental_agreement'
     | 'passport_registration'
     | 'temporary_registration'
-    | '[hone_number'
+    | 'phone_number'
     | 'email';
   /**
    * _Optional._ Base64-encoded encrypted  Passport element data provided by the user, available for “personal_details”,


### PR DESCRIPTION
Fix typo in TelegramEncryptedPassportElement interface in telegramTypes.interface.ts on line 1569.